### PR TITLE
support replicate api token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,19 @@ This builds `./yolo`, you can install by copying into your path.
 
     sudo cp yolo /usr/local/bin
 
-### Get your Replicate CLI auth token
+### Get your Replicate token
+
+You can use **either** your REPLICATE_API_TOKEN or your COG_TOKEN.
+
+By using your REPLICATE_API_TOKEN, we can access the API and PUSH models to your account.
+
+#### Replicate API Token
+
+Visit https://replicate.com/account/api-tokens and copy your token.
+
+    export REPLICATE_API_TOKEN=r8_...
+
+#### Cog Token
 
 Visit https://replicate.com/auth/token and copy your token.
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -32,6 +32,7 @@ func VerifyCogToken(registryHost string, token string) (username string, err err
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("failed to verify token, got status %d", resp.StatusCode)
 	}
+	defer resp.Body.Close()
 	body := &struct {
 		Username string `json:"username"`
 	}{}

--- a/pkg/cli/fetch.go
+++ b/pkg/cli/fetch.go
@@ -19,7 +19,7 @@ func newFetchCommand() *cobra.Command {
 		Args:   cobra.ExactArgs(1),
 	}
 
-	cmd.Flags().StringVarP(&sToken, "token", "t", "", "replicate cog token")
+	cmd.Flags().StringVarP(&sToken, "token", "t", "", "replicate api token")
 	cmd.Flags().StringVarP(&sRegistry, "registry", "r", "r8.im", "registry host")
 	cmd.Flags().StringVarP(&baseRef, "base", "b", "", "base image reference - include tag: r8.im/username/modelname@sha256:hexdigest")
 	cmd.MarkFlagRequired("base")
@@ -30,9 +30,14 @@ func newFetchCommand() *cobra.Command {
 func fetchCommmand(cmd *cobra.Command, args []string) error {
 	dest := args[0]
 	if sToken == "" {
+		sToken = os.Getenv("REPLICATE_API_TOKEN")
+	}
+
+	if sToken == "" {
 		sToken = os.Getenv("COG_TOKEN")
 	}
 
+	// FIXME(ja): support fetching public images without auth?
 	u, err := auth.VerifyCogToken(sRegistry, sToken)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "authentication error, invalid token or registry host error")

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -32,7 +32,7 @@ func newPushCommand() *cobra.Command {
 		Args:   cobra.MinimumNArgs(1),
 	}
 
-	cmd.Flags().StringVarP(&sToken, "token", "t", "", "replicate cog token")
+	cmd.Flags().StringVarP(&sToken, "token", "t", "", "replicate api token")
 	cmd.Flags().StringVarP(&sRegistry, "registry", "r", "r8.im", "registry host")
 	cmd.Flags().StringVarP(&baseRef, "base", "b", "", "base image reference - include tag: r8.im/username/modelname@sha256:hexdigest")
 	cmd.MarkFlagRequired("base")
@@ -45,6 +45,10 @@ func newPushCommand() *cobra.Command {
 }
 
 func pushCommmand(cmd *cobra.Command, args []string) error {
+	if sToken == "" {
+		sToken = os.Getenv("REPLICATE_API_TOKEN")
+	}
+
 	if sToken == "" {
 		sToken = os.Getenv("COG_TOKEN")
 	}


### PR DESCRIPTION
@zeke recommended we use REPLICATE_API_TOKEN as it:

- works with r8.im
- allows us to access the replicate api to get additional information

This could allow specifying `owner/model` instead of a full sha to mean the latest version of a model

addresses #2 