### PR TITLE
Negative numbers!

### DIFF
--- a/pkg/images/ast_openapi_schema.py
+++ b/pkg/images/ast_openapi_schema.py
@@ -322,8 +322,6 @@ def get_value(node: ast.AST) -> "int | float | complex | str | list":
     if isinstance(node, ast.UnaryOp):
         if isinstance(node.op, ast.USub):
             return -get_value(node.operand)
-        if isinstance(node.op, ast.UAdd):
-            return get_value(node.operand)
 
     print(f"Error on line {node.lineno}")
 

--- a/pkg/images/ast_openapi_schema.py
+++ b/pkg/images/ast_openapi_schema.py
@@ -319,6 +319,11 @@ def get_value(node: ast.AST) -> "int | float | complex | str | list":
         return node.n
     if isinstance(node, (ast.List, ast.Tuple)):
         return [get_value(e) for e in node.elts]
+    if isinstance(node, ast.UnaryOp):
+        if isinstance(node.op, ast.USub):
+            return -get_value(node.operand)
+        if isinstance(node.op, ast.UAdd):
+            return get_value(node.operand)
 
     print(f"Error on line {node.lineno}")
 


### PR DESCRIPTION
If an input parameter has a default value of negative something (i.e. `-1`), the ast parsing code will parse an `ast.unaryOp` and fails. This fixes that.
