### PR TITLE
squash yolo - for push, clone and fetch

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -5,22 +5,18 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 )
 
-func addressWithScheme(address string) string {
-	if strings.Contains(address, "://") {
-		return address
-	}
-	return "https://" + address
+type responseBody struct {
+	Username string `json:"username"`
 }
 
-func VerifyCogToken(registryHost string, token string) (username string, err error) {
+func VerifyCogToken(token string) (username string, err error) {
 	if token == "" {
 		return "", fmt.Errorf("token is required")
 	}
 
-	resp, err := http.PostForm(addressWithScheme(registryHost)+"/cog/v1/verify-token", url.Values{
+	resp, err := http.PostForm("https://r8.im/cog/v1/verify-token", url.Values{
 		"token": []string{token},
 	})
 	if err != nil {
@@ -33,11 +29,11 @@ func VerifyCogToken(registryHost string, token string) (username string, err err
 		return "", fmt.Errorf("failed to verify token, got status %d", resp.StatusCode)
 	}
 	defer resp.Body.Close()
-	body := &struct {
-		Username string `json:"username"`
-	}{}
+
+	body := &responseBody{}
 	if err := json.NewDecoder(resp.Body).Decode(body); err != nil {
 		return "", err
 	}
+
 	return body.Username, nil
 }

--- a/pkg/cli/clone.go
+++ b/pkg/cli/clone.go
@@ -18,7 +18,6 @@ func newCloneCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&sToken, "token", "t", "", "replicate api token")
-	cmd.Flags().StringVarP(&sRegistry, "registry", "r", "r8.im", "registry host")
 	cmd.Flags().StringVarP(&baseRef, "base", "b", "", "base image reference.  examples: owner/model or r8.im/owner/model@sha256:hexdigest")
 	cmd.Flags().StringVarP(&dest, "dest", "d", "", "destination image. examples: owner/model or r8.im/owner/model")
 	cmd.MarkFlagRequired("base")
@@ -34,10 +33,10 @@ func cloneCommmand(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	baseRef = ensureRegistry(baseRef)
-	dest = ensureRegistry(dest)
+	baseRef = images.EnsureRegistry(baseRef)
+	dest = images.EnsureRegistry(dest)
 
-	image_id, err := images.Affix(baseRef, dest, nil, "", "", session)
+	image_id, err := images.Clone(baseRef, dest, session)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/fetch.go
+++ b/pkg/cli/fetch.go
@@ -18,7 +18,6 @@ func newFetchCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&sToken, "token", "t", "", "replicate api token")
-	cmd.Flags().StringVarP(&sRegistry, "registry", "r", "r8.im", "registry host")
 	cmd.Flags().StringVarP(&baseRef, "base", "b", "", "base image reference.  examples: owner/model or r8.im/owner/model@sha256:hexdigest")
 	cmd.MarkFlagRequired("base")
 
@@ -34,6 +33,6 @@ func fetchCommmand(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	baseRef = ensureRegistry(baseRef)
+	baseRef = images.EnsureRegistry(baseRef)
 	return images.Extract(baseRef, dest, session)
 }

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -14,14 +14,13 @@ import (
 )
 
 var (
-	sToken    string
-	sRegistry string
-	sBaseApi  string
-	baseRef   string
-	dest      string
-	ast       string
-	commit    string
-	sampleDir string
+	sToken        string
+	sBaseApi      string
+	baseRef       string
+	dest          string
+	ast           string
+	commit        string
+	sampleDir     string
 	relativePaths bool
 )
 
@@ -35,7 +34,6 @@ func newPushCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&sToken, "token", "t", "", "replicate api token")
-	cmd.Flags().StringVarP(&sRegistry, "registry", "r", "r8.im", "registry host")
 	cmd.Flags().BoolVarP(&relativePaths, "relative-paths", "p", false, "preserve relative paths from where yolo is run instead of placing all files under /src")
 	cmd.Flags().StringVarP(&baseRef, "base", "b", "", "base image reference.  examples: owner/model or r8.im/owner/model@sha256:hexdigest")
 	cmd.MarkFlagRequired("base")
@@ -61,8 +59,8 @@ func pushCommmand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRef = ensureRegistry(baseRef)
-	dest = ensureRegistry(dest)
+	baseRef = images.EnsureRegistry(baseRef)
+	dest = images.EnsureRegistry(dest)
 
 	image_id, err := images.Affix(baseRef, dest, tar, ast, commit, session)
 	if err != nil {

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -1,13 +1,10 @@
 package cli
 
 import (
-	"archive/tar"
-	"bytes"
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
 
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/replicate/yolo/pkg/auth"
 	"github.com/replicate/yolo/pkg/images"
 	"github.com/spf13/cobra"
@@ -54,13 +51,26 @@ func pushCommmand(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	tar, err := makeTar(args)
+	baseRef = images.EnsureRegistry(baseRef)
+	dest = images.EnsureRegistry(dest)
+
+	base, err := crane.Pull(baseRef, crane.WithAuth(session))
+	if err != nil {
+		return fmt.Errorf("pulling %w", err)
+	}
+
+	yoloLayers, err := images.GetSourceLayers(base, false, true)
 	if err != nil {
 		return err
 	}
 
-	baseRef = images.EnsureRegistry(baseRef)
-	dest = images.EnsureRegistry(dest)
+	// FIXME(ja): I think there should be a method images.UpdateYolo
+	// that takes the new files and updates the yolo if it exists
+	// -- Affix is too low level for this?
+	tar, err := images.MakeTar(args, relativePaths, yoloLayers)
+	if err != nil {
+		return err
+	}
 
 	image_id, err := images.Affix(baseRef, dest, tar, ast, commit, session)
 	if err != nil {
@@ -78,48 +88,4 @@ func pushCommmand(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func makeTar(args []string) (*bytes.Buffer, error) {
-	buf := new(bytes.Buffer)
-	tw := tar.NewWriter(buf)
-
-	for _, file := range args {
-		f, err := os.Open(file)
-		if err != nil {
-			return nil, err
-		}
-		defer f.Close()
-
-		stat, err := f.Stat()
-		if err != nil {
-			return nil, err
-		}
-		var dest string
-		if relativePaths {
-			dest = filepath.Join("src", file)
-		} else {
-			baseName := filepath.Base(file)
-			dest = filepath.Join("src", baseName)
-		}
-		fmt.Fprintln(os.Stderr, "adding:", dest)
-
-		hdr := &tar.Header{
-			Name: dest,
-			Mode: int64(stat.Mode()),
-			Size: stat.Size(),
-		}
-		if err := tw.WriteHeader(hdr); err != nil {
-			return nil, err
-		}
-		if _, err := io.Copy(tw, f); err != nil {
-			return nil, err
-		}
-	}
-
-	if err := tw.Close(); err != nil {
-		return nil, err
-	}
-
-	return buf, nil
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -42,7 +41,7 @@ func authenticate() authn.Authenticator {
 	}
 
 	if sToken != "" {
-		u, err := auth.VerifyCogToken(sRegistry, sToken)
+		u, err := auth.VerifyCogToken(sToken)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "authentication error, invalid token or registry host error")
 			return nil
@@ -51,11 +50,4 @@ func authenticate() authn.Authenticator {
 	}
 
 	return authn.Anonymous
-}
-
-func ensureRegistry(baseRef string) string {
-	if !strings.Contains(baseRef, sRegistry) {
-		return sRegistry + "/" + baseRef
-	}
-	return baseRef
 }

--- a/pkg/images/affix.go
+++ b/pkg/images/affix.go
@@ -22,11 +22,8 @@ var script string
 
 func Affix(baseRef string, dest string, newLayer *bytes.Buffer, predictorToParse string, commit string, session authn.Authenticator) (string, error) {
 
-	var base v1.Image
-	var err error
-
 	fmt.Fprintln(os.Stderr, "fetching metadata for", baseRef)
-	base, err = crane.Pull(baseRef, crane.WithAuth(session))
+	base, err := crane.Pull(baseRef, crane.WithAuth(session))
 	if err != nil {
 		return "", fmt.Errorf("pulling %w", err)
 	}

--- a/pkg/images/clone.go
+++ b/pkg/images/clone.go
@@ -1,0 +1,43 @@
+package images
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+)
+
+func Clone(baseRef string, dest string, session authn.Authenticator) (string, error) {
+
+	fmt.Fprintln(os.Stderr, "fetching metadata for", baseRef)
+	base, err := crane.Pull(baseRef, crane.WithAuth(session))
+	if err != nil {
+		return "", fmt.Errorf("pulling %w", err)
+	}
+
+	// as r8.im fails if you push the same image to a second location,
+	// we can work around this by adding a label "cloned" with the current time
+	cfg, err := base.ConfigFile()
+	if err != nil {
+		return "", fmt.Errorf("getting config file: %w", err)
+	}
+	cfg.Config.Labels["cloned"] = time.Now().String()
+
+	img, err := mutate.ConfigFile(base, cfg)
+	if err != nil {
+		return "", fmt.Errorf("mutating config file: %w", err)
+	}
+
+	start := time.Now()
+	err = crane.Push(img, dest, crane.WithAuth(session))
+	if err != nil {
+		return "", fmt.Errorf("pushing %s: %w", dest, err)
+	}
+	fmt.Fprintln(os.Stderr, "pushing took", time.Since(start))
+
+	return ImageId(dest, img)
+}

--- a/pkg/images/extract.go
+++ b/pkg/images/extract.go
@@ -14,7 +14,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
-func Extract(baseRef string, dest string, auth authn.Authenticator) error {
+func Extract(baseRef string, dest string, session authn.Authenticator) error {
 	var err error
 
 	if _, err = os.Stat(dest); !os.IsNotExist(err) {
@@ -25,7 +25,7 @@ func Extract(baseRef string, dest string, auth authn.Authenticator) error {
 
 	fmt.Fprintln(os.Stderr, "fetching metadata for", baseRef)
 
-	base, err = crane.Pull(baseRef, crane.WithAuth(auth))
+	base, err = crane.Pull(baseRef, crane.WithAuth(session))
 	if err != nil {
 		return fmt.Errorf("pulling %w", err)
 	}

--- a/pkg/images/names.go
+++ b/pkg/images/names.go
@@ -8,6 +8,10 @@ import (
 )
 
 func EnsureRegistry(baseRef string) string {
+	if strings.Contains(baseRef, ":") && !strings.Contains(baseRef, "@") {
+		sha := strings.Split(baseRef, ":")[1]
+		baseRef = strings.Split(baseRef, ":")[0] + "@sha256:" + sha
+	}
 	if !strings.Contains(baseRef, "r8.im") {
 		return "r8.im/" + baseRef
 	}

--- a/pkg/images/names.go
+++ b/pkg/images/names.go
@@ -1,0 +1,24 @@
+package images
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func EnsureRegistry(baseRef string) string {
+	if !strings.Contains(baseRef, "r8.im") {
+		return "r8.im/" + baseRef
+	}
+	return baseRef
+}
+
+func ImageId(baseRef string, img v1.Image) (string, error) {
+	d, err := img.Digest()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s@%s", EnsureRegistry(baseRef), d), nil
+}

--- a/pkg/images/schema.go
+++ b/pkg/images/schema.go
@@ -1,0 +1,25 @@
+package images
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"os/exec"
+)
+
+//go:embed ast_openapi_schema.py
+var ast_openapi_schema string
+
+func getSchema(predictorToParse string) (string, error) {
+	cmd := exec.Command("python3", "-c", ast_openapi_schema, predictorToParse)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("running ast_openapi_schema.py: %w", err)
+	}
+
+	schema := string(bytes.TrimSpace(out.Bytes()))
+	return schema, nil
+}

--- a/pkg/images/src.go
+++ b/pkg/images/src.go
@@ -1,0 +1,35 @@
+package images
+
+import v1 "github.com/google/go-containerregistry/pkg/v1"
+
+// returns /src layers created by yolo and/or cog, oldest layers first
+func GetSourceLayers(base v1.Image, cog bool, yolo bool) ([]v1.Layer, error) {
+	var srcLayers []v1.Layer
+
+	cfg, err := base.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+
+	layers, err := base.Layers()
+	if err != nil {
+		return nil, err
+	}
+
+	idx := 0
+	for _, h := range cfg.History {
+		if h.EmptyLayer {
+			continue
+		}
+
+		if yolo && h.CreatedBy == "cp . /src # yolo" {
+			srcLayers = append(srcLayers, layers[idx])
+		}
+		if cog && h.CreatedBy == "COPY . /src # buildkit" {
+			srcLayers = append(srcLayers, layers[idx])
+		}
+		idx++
+	}
+
+	return srcLayers, nil
+}

--- a/pkg/images/tar.go
+++ b/pkg/images/tar.go
@@ -1,0 +1,97 @@
+package images
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func MakeTar(args []string, relative bool, layers []v1.Layer) (*bytes.Buffer, error) {
+	added := make(map[string]struct{})
+
+	buf := new(bytes.Buffer)
+	tw := tar.NewWriter(buf)
+
+	for _, file := range args {
+		f, err := os.Open(file)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		stat, err := f.Stat()
+		if err != nil {
+			return nil, err
+		}
+
+		var dest string
+		if relative {
+			dest = filepath.Join("src", file)
+		} else {
+			baseName := filepath.Base(file)
+			dest = filepath.Join("src", baseName)
+		}
+
+		fmt.Fprintln(os.Stderr, "adding:", dest)
+
+		hdr := &tar.Header{
+			Name: dest,
+			Mode: int64(stat.Mode()),
+			Size: stat.Size(),
+		}
+		added[hdr.Name] = struct{}{}
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if _, err := io.Copy(tw, f); err != nil {
+			return nil, err
+		}
+	}
+
+	// we need to add all the layers in reverse order, so that files from
+	// the most recent layer is included (not skipped)
+	for i := len(layers) - 1; i >= 0; i-- {
+		layer := layers[i]
+		rc, err := layer.Uncompressed()
+		if err != nil {
+			return nil, err
+		}
+
+		tr := tar.NewReader(rc)
+		for {
+			header, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			if _, ok := added[header.Name]; ok {
+				fmt.Fprintln(os.Stderr, "skipping:", header.Name)
+				continue
+			}
+
+			fmt.Fprintln(os.Stderr, "including prior:", header.Name)
+
+			if err := tw.WriteHeader(header); err != nil {
+				return nil, err
+			}
+			if _, err := io.Copy(tw, tr); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}

--- a/pkg/images/tar.go
+++ b/pkg/images/tar.go
@@ -86,6 +86,8 @@ func MakeTar(args []string, relative bool, layers []v1.Layer) (*bytes.Buffer, er
 			if _, err := io.Copy(tw, tr); err != nil {
 				return nil, err
 			}
+
+			added[header.Name] = struct{}{}
 		}
 	}
 

--- a/pkg/images/yolo.go
+++ b/pkg/images/yolo.go
@@ -140,7 +140,7 @@ func removeYolo(orig v1.Image) (v1.Image, error) {
 		return nil, fmt.Errorf("failed to get config for original: %w", err)
 	}
 
-	rebasedImage, err := mutate.Config(empty.Image, *config.Config.DeepCopy())
+	yololessImage, err := mutate.Config(empty.Image, *config.Config.DeepCopy())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create empty image with original config: %w", err)
 	}
@@ -158,7 +158,7 @@ func removeYolo(orig v1.Image) (v1.Image, error) {
 			}
 
 			fmt.Println("adding layer", add.Layer, "with history", h)
-			rebasedImage, err = mutate.Append(rebasedImage, add)
+			yololessImage, err = mutate.Append(yololessImage, add)
 			if err != nil {
 				return nil, fmt.Errorf("failed to add layer: %w", err)
 			}
@@ -169,5 +169,5 @@ func removeYolo(orig v1.Image) (v1.Image, error) {
 		}
 	}
 
-	return rebasedImage, nil
+	return yololessImage, nil
 }

--- a/pkg/images/yolo.go
+++ b/pkg/images/yolo.go
@@ -6,49 +6,58 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/stream"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-//go:embed ast_openapi_schema.py
-var script string
-
-func Affix(baseRef string, dest string, newLayer *bytes.Buffer, predictorToParse string, commit string, session authn.Authenticator) (string, error) {
-
+func Yolo(baseRef string, dest string, files []LayerFile, predictorToParse string, commit string, session authn.Authenticator) (string, error) {
 	fmt.Fprintln(os.Stderr, "fetching metadata for", baseRef)
 	base, err := crane.Pull(baseRef, crane.WithAuth(session))
 	if err != nil {
 		return "", fmt.Errorf("pulling %w", err)
 	}
 
+	yoloLess, err := removeYolo(base)
+	if err != nil {
+		return "", fmt.Errorf("removing existing yolo layers: %w", err)
+	}
+
 	// try to parse the predictor if it's provided
 	if predictorToParse != "" {
-		base, err = updatePredictor(base, predictorToParse)
+		yoloLess, err = updatePredictor(yoloLess, predictorToParse)
 		if err != nil {
 			return "", fmt.Errorf("updating predictor: %w", err)
 		}
 	}
 
 	if commit != "" {
-		base, err = updateCommit(base, commit)
+		yoloLess, err = updateCommit(yoloLess, commit)
 		if err != nil {
 			return "", fmt.Errorf("updating commit: %w", err)
 		}
 	}
 
-	// FIXME(ja): find any YOLOs in the history and remove them?  We don't want to grow the history forever
-
 	fmt.Fprintln(os.Stderr, "appending as new layer")
 	var img v1.Image
 
-	img, err = appendLayer(base, newLayer)
+	yoloLayers, err := GetSourceLayers(base, false, true)
+	if err != nil {
+		return "", fmt.Errorf("getting source layers: %w", err)
+	}
+
+	newLayer, err := MakeTar(files, yoloLayers)
+	if err != nil {
+		return "", fmt.Errorf("making tar: %w", err)
+	}
+
+	img, err = appendLayer(yoloLess, newLayer)
 	if err != nil {
 		return "", fmt.Errorf("appending %v: %w", newLayer, err)
 	}
@@ -118,16 +127,47 @@ func updatePredictor(img v1.Image, predictorToParse string) (v1.Image, error) {
 	return mutate.Config(img, cfg.Config)
 }
 
-func getSchema(predictorToParse string) (string, error) {
-	cmd := exec.Command("python3", "-c", script, predictorToParse)
-
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
+// we need to remove any existing yolo layers before adding more... otherwise
+// we'll end up with a bunch of yolo layers
+func removeYolo(orig v1.Image) (v1.Image, error) {
+	layers, err := orig.Layers()
 	if err != nil {
-		return "", fmt.Errorf("running ast_openapi_schema.py: %w", err)
+		return nil, fmt.Errorf("failed to get layers for original: %w", err)
 	}
 
-	schema := string(bytes.TrimSpace(out.Bytes()))
-	return schema, nil
+	config, err := orig.ConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config for original: %w", err)
+	}
+
+	rebasedImage, err := mutate.Config(empty.Image, *config.Config.DeepCopy())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create empty image with original config: %w", err)
+	}
+
+	idx := 0
+	for _, h := range config.History {
+
+		if h.CreatedBy != "cp . /src # yolo" {
+			add := mutate.Addendum{
+				Layer:   nil,
+				History: h,
+			}
+			if !h.EmptyLayer {
+				add.Layer = layers[idx]
+			}
+
+			fmt.Println("adding layer", add.Layer, "with history", h)
+			rebasedImage, err = mutate.Append(rebasedImage, add)
+			if err != nil {
+				return nil, fmt.Errorf("failed to add layer: %w", err)
+			}
+		}
+
+		if !h.EmptyLayer {
+			idx++
+		}
+	}
+
+	return rebasedImage, nil
 }


### PR DESCRIPTION
- when fetching you should get all the /src layers
- when pushing - we should make it so you don't end up with lots of yolo layers