### PR TITLE
Fix goreleaser asset name template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,8 +21,7 @@ archives:
       {{ .ProjectName }}_{{ .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}
-      {{end}}
+      {{- else }}{{ .Arch }}{{end -}}
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
 archives:
   - format: binary
     name_template: >-
-      {{ .ProjectName }}_{{ .Os }}_
+      {{ .ProjectName }}_{{ title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{end -}}


### PR DESCRIPTION
This PR updates the goreleaser config, and should solve two issues:

- Remove trailing whitespace in ilename which was causing goreleaser to prepend `default.` to some asset names. See https://github.com/goreleaser/goreleaser/issues/4513#issuecomment-1875312372
- Capitalize OS names like `Darwin` and `Linux` so you can use `uname -s` to construct OS-specific download URLs.

Resolves https://github.com/replicate/yolo/issues/13

cc @anotherjesse 